### PR TITLE
Update gamma/Z ratio JES variation calculation in monojet/mono-V

### DIFF
--- a/makeWorkspace/Z_constraints.py
+++ b/makeWorkspace/Z_constraints.py
@@ -286,8 +286,8 @@ def cmodel(cid,nam,_f,_fOut, out_ws, diag, year):
     add_variation(ZeeScales, fjes, 'znunu_over_zee{YEAR}_qcd_{VARIATION}Down'.format(YEAR=year-2000, VARIATION=var), "zee_weights_%s_%s_Down"%(cid, var), _fOut)
     CRs[2].add_nuisance_shape(var,_fOut)
 
-    add_variation(PhotonScales, fjes, 'gjets_over_znunu{YEAR}_qcd_{VARIATION}Up'.format(YEAR=year-2000, VARIATION=var), "photon_weights_%s_%s_Up"%(cid, var), _fOut, invert=True)
-    add_variation(PhotonScales, fjes, 'gjets_over_znunu{YEAR}_qcd_{VARIATION}Down'.format(YEAR=year-2000, VARIATION=var), "photon_weights_%s_%s_Down"%(cid, var), _fOut, invert=True)
+    add_variation(PhotonScales, fjes, 'znunu_over_gjets{YEAR}_qcd_{VARIATION}Up'.format(YEAR=year-2000, VARIATION=var), "photon_weights_%s_%s_Up"%(cid, var), _fOut)
+    add_variation(PhotonScales, fjes, 'znunu_over_gjets{YEAR}_qcd_{VARIATION}Down'.format(YEAR=year-2000, VARIATION=var), "photon_weights_%s_%s_Down"%(cid, var), _fOut)
     CRs[0].add_nuisance_shape(var,_fOut)
 
   cat = Category(model,cid,nam,_fin,_fOut,_wspace,out_ws,_bins,metname,target.GetName(),CRs,diag)


### PR DESCRIPTION
Hey @AndreasAlbert, @siqiyyyy, Siqi identified a problem with the current JES uncertainty code for monojet and mono-V. In the original version of the code, we were reading variations for gamma/Z and inverting it. But in the histograms we store Z/gamma. So in this PR I renamed the histograms accordingly and removed the inversion option. Let me know what you think and if you want more changes to this, thanks! 