### PR TITLE
add ulimit command to remove stack size

### DIFF
--- a/combine_vj/scripts/diagnostics.sh
+++ b/combine_vj/scripts/diagnostics.sh
@@ -3,6 +3,9 @@
 mkdir -p diagnostics
 pushd diagnostics
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 for YEAR in 2017 2018 combined; do
         combine -M FitDiagnostics \
                 --saveShapes \

--- a/combine_vj/scripts/gof_split.sh
+++ b/combine_vj/scripts/gof_split.sh
@@ -1,6 +1,9 @@
 mkdir -p gof
 pushd gof
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 function gof() {
     YEAR=$1
     MASK=$2

--- a/combine_vj/scripts/limit.sh
+++ b/combine_vj/scripts/limit.sh
@@ -2,6 +2,9 @@
 mkdir -p limit
 pushd limit
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 for YEAR in 2017 2018 combined; do
     combine -M AsymptoticLimits -t -1 -n monojet_monov_nominal_${YEAR} ../cards/card_monojet_monov_nominal_${YEAR}.root --setParameters LUMISCALE=1 --freezeParameters LUMISCALE | tee log_${YEAR}.txt &
 done

--- a/combine_vj/scripts/make_combined_card.sh
+++ b/combine_vj/scripts/make_combined_card.sh
@@ -5,6 +5,9 @@ cd /afs/cern.ch/work/a/aalbert/public/2020-03-09_limit/monox_fit/combine_vj/
 JDIR=$(readlink -e ../monojet/${TAG}/${SUBTAG}/)
 VDIR=$(readlink -e ../monov/${TAG}/${SUBTAG}/)
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 WDIR=./${TAG}/${SUBTAG}_${SUBSUBTAG}/
 mkdir -p $WDIR
 pushd $WDIR

--- a/monojet/scripts/diagnostics.sh
+++ b/monojet/scripts/diagnostics.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 mkdir -p diagnostics
 pushd diagnostics
+
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 # Individual years
 for YEAR in 2017 2018 combined; do
     combine -M FitDiagnostics \

--- a/monojet/scripts/gof.sh
+++ b/monojet/scripts/gof.sh
@@ -1,6 +1,9 @@
 mkdir -p gof
 pushd gof
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 function gof() {
     YEAR=$1
     MASK=$2

--- a/monojet/scripts/impacts.sh
+++ b/monojet/scripts/impacts.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 do_impacts(){
     YEAR=${1}
     SIGNAL=${2}

--- a/monojet/scripts/impacts_condor.sh
+++ b/monojet/scripts/impacts_condor.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 do_impacts(){
     YEAR=${1}
     SIGNAL=${2}

--- a/monojet/scripts/limits.sh
+++ b/monojet/scripts/limits.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 ### Asimov limit
 mkdir -p limit
 pushd limit

--- a/monojet/scripts/make_cards.sh
+++ b/monojet/scripts/make_cards.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 mkdir -p cards
 # Fill templates
 for YEAR in 2017 2018; do

--- a/monojet/scripts/run.sh
+++ b/monojet/scripts/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 ### Fit diagnostics
 mkdir -p diagnostics
 pushd diagnostics

--- a/monov/scripts/diagnostics.sh
+++ b/monov/scripts/diagnostics.sh
@@ -2,6 +2,9 @@
 mkdir -p diagnostics
 pushd diagnostics
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 # Year by year
 for YEAR in 2017 2018; do
     for TAGGER in nominal; do

--- a/monov/scripts/impacts.sh
+++ b/monov/scripts/impacts.sh
@@ -3,6 +3,9 @@
 TAGGER="nominal"
 WP="tight"
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 ### Impacts
 
 # Separately by year

--- a/monov/scripts/limits.sh
+++ b/monov/scripts/limits.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 ### Asimov limit
 mkdir -p limit
 pushd limit

--- a/monov/scripts/make_cards.sh
+++ b/monov/scripts/make_cards.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 mkdir -p cards
 
 for YEAR in 2017 2018; do

--- a/monov/scripts/run.sh
+++ b/monov/scripts/run.sh
@@ -1,5 +1,9 @@
 mkdir -p limit
 pushd limit
+
+#remove limit on stack size to prevent related segfault
+ulimit -s unlimited
+
 for file in ../cards/*.root; do
 
     TAG=$(basename $file | sed 's/card_//g;s/.root//g');


### PR DESCRIPTION
This fixed the issue when text2workspace large data cards there could be a segfault related to exceeding the stack size.

Running `ulimit -s unlimited` before saving or accessing the workspace in datacard root file can prevent the segfault from happening. This PR add the command to every scripts.